### PR TITLE
Fix: broken download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,4 +200,4 @@ Note that shortcuts will be created by default unless disabled.
 
 ## Download
 
-Download the [latest version](https://github.com/asheroto/Deploy-Office/releases/latest/download/Deploy-Office.zip) in the releases section.
+Download the [latest version](https://github.com/asheroto/Deploy-Office/releases/latest/download/Deploy-Office.exe) in the releases section.


### PR DESCRIPTION
Fix the broken link in the Download section (last paragraph of the README.md), which redirected to an unexistent .zip file, and now redirects to a .exe, working correctly.